### PR TITLE
Fix lap graph save

### DIFF
--- a/demo/app/lap-graph/lapGraph.component.html
+++ b/demo/app/lap-graph/lapGraph.component.html
@@ -7,4 +7,26 @@
   </div>
 </div>
 
-<app-settings *ngIf="item.edit" [item]="item" [size]="size" [gridItems]="gridItems"></app-settings>
+<div *ngIf="item.edit" class="edit wrapper">
+  <div class="scroller margin-bottom-50">
+    <div class="drivers" *ngFor="let driver of data.lapData">
+      <div (click)="toggle(driver)" [ngClass]="{selected: selectedItems.includes(driver)}" class="item-container settings">
+        <div class="car-number settings">
+        </div>
+        <div class="driver-name settings">
+          <span>{{driver.name}}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="bottom" [ngClass]="{'bottom-10': getHeight(item.id) === 200}">
+      <div class="button settings" [ngClass]="{disabled: maxItems()}" (click)="copy(item)">
+        <span class="button-text">Duplicate</span>
+      </div>
+      <div class="button settings" [ngClass]="{disabled: selectedItems.length === 0}" (click)="updateGraph(item)">
+        <span class="button-text">Save</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/demo/app/lap-graph/lapGraph.component.ts
+++ b/demo/app/lap-graph/lapGraph.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { LapGraphService } from './lapGraph.service';
 import { GridItemService } from '../shared/gridItem.service';
 import { ConfigService } from '../shared/config.service';
-import { SelectionComponent } from '../shared/selection.component';
 import * as Highcharts from 'highcharts';
 
 

--- a/demo/app/lap-graph/lapGraph.component.ts
+++ b/demo/app/lap-graph/lapGraph.component.ts
@@ -58,10 +58,10 @@ export class LapGraphComponent extends GridItemService implements OnInit {
     this.maxX = event.context.max;
   }
 
-  updateGraph(): void {
+  updateGraph(item: any): void {
     if (this.selectedItems.length === 0) { return; }
     this.options.series = this.selectedItems;
     this.selectedItems = [];
-    this.edit = false;
+    item.edit = false;
   }
 }

--- a/demo/app/lap-graph/lapGraph.service.ts
+++ b/demo/app/lap-graph/lapGraph.service.ts
@@ -4,10 +4,6 @@ import { Injectable } from '@angular/core';
 
 export class LapGraphService {
 
-  public driverNames: Array<string> = [
-    'Joey Logano', 'Austin Dillon', 'Ryan Blaney'
-  ];
-
   public lapData: Array<any> = [
     {
       id: 1,

--- a/demo/app/shared/gridItem.service.ts
+++ b/demo/app/shared/gridItem.service.ts
@@ -47,10 +47,6 @@ export class GridItemService {
     }
   }
 
-  log(): void {
-    console.log(this.size):
-  }
-
   update(item: any): void {
     item = this.selectedItems;
     this.selectedItems = [];


### PR DESCRIPTION
The generic `SettingsComponent` I started setting up for the Grid Items' edit states was using just a basic list of example driver names instead of actual objects specific to the Grid Items' themselves. I extracted some of the edit view html and changed the data represented as `item`.